### PR TITLE
Removed unnecessary LINQ usage in AmbientEvent

### DIFF
--- a/SuperEvents/AmbientEvent.cs
+++ b/SuperEvents/AmbientEvent.cs
@@ -128,18 +128,18 @@ public abstract class AmbientEvent
         OnCleanup();
         if (forceCleanup)
         {
-            foreach (var entity in EntitiesToClear.Where(entity => entity))
+            foreach (var entity in EntitiesToClear)
                 if (entity.Exists()) entity.Delete();
             Log.Info("Event has been forcefully cleaned up.");
         }
         else
         {
-            foreach (var entity in EntitiesToClear.Where(entity => entity))
+            foreach (var entity in EntitiesToClear)
                 if (entity.Exists()) entity.Dismiss();
             Game.DisplayHelp("~y~Event Ended.");
         }
 
-        foreach (var blip in BlipsToClear.Where(blip => blip))
+        foreach (var blip in BlipsToClear)
             if (blip.Exists()) blip.Delete();
 
         Interaction.CloseAllMenus();


### PR DESCRIPTION
Code is identical in practice but makes fewer LINQ calls as `.Where(entity => entity)` would always return true unless it was null, which `.Exists()` checks anyway.