### PR TITLE
Slight refactoring for attribute extension and event manager

### DIFF
--- a/SuperEvents/Attributes/AttributeExtensions.cs
+++ b/SuperEvents/Attributes/AttributeExtensions.cs
@@ -14,7 +14,7 @@ internal static class AttributeExtensions
     /// <exception cref="AttributeExpectedException">Thrown if the event does not have an <see cref="EventInfoAttribute"/> assigned.</exception>
     internal static (string Title, string Description) GetEventInfo(this Type type)
     {
-        if (type.BaseType != typeof(AmbientEvent))
+        if (!type.IsSubclassOf(typeof(AmbientEvent)))
             throw new ArgumentException($"SuperEvents: ERROR: {type.Name} Type was not of Type AmbientEvent");
         if (type.GetCustomAttributes(typeof(EventInfoAttribute), true).FirstOrDefault() is not EventInfoAttribute att)
             throw new AttributeExpectedException(

--- a/SuperEvents/EventFunctions/EventManager.cs
+++ b/SuperEvents/EventFunctions/EventManager.cs
@@ -77,9 +77,8 @@ public static class EventManager
                 if (EventTimer.Finished && CurrentEvent == null) StartRandomEvent(); // TODO: Timer Ended
             }
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not ThreadAbortException)
         {
-            if (e is ThreadAbortException) return;
             Log.Error(e.ToString());
         }
     }


### PR DESCRIPTION
Made the events work even if it has multi-layer inheritance (For example if someone creates their own subclass of AmbientEvent, then inherits from that for their own sake.)

Added the cleaner line for ThreadAbortException try catch.

### **PLEASE TEST BEFORE MERGING**